### PR TITLE
Fix: 'jwt is not a function' by updating package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "express-jwt": "^6.0.0",
+    "express-jwt": "^7.0.0",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.1.2",
     "morgan": "^1.10.0"


### PR DESCRIPTION
@sandrabosk @ross-u v6 of express-jwt has a different setup. It looks like the rest of this code is following v7 while package.json is referencing v6